### PR TITLE
fix(src): greeting structure and receipt

### DIFF
--- a/src/GlobalGreeter.sol
+++ b/src/GlobalGreeter.sol
@@ -21,7 +21,7 @@ contract GlobalGreeter is XApp {
      * @notice The latest greeting recorded by the contract
      * @dev State variable to store information about the latest greeting received by the contract
      */
-    Greeting public lastGreet = Greeting(0, 0, 0, address(0), address(0), "Hello Omni!");
+    Greeting public lastGreet = Greeting(0, 0, address(0), "Hello Omni!");
 
     /**
      * @dev Initializes a new GlobalGreeter contract with the specified portal address
@@ -36,16 +36,9 @@ contract GlobalGreeter is XApp {
      *      It updates the lastGreet variable with information about the received greeting.
      */
     function greet(string calldata _greeting) external xrecv {
-        // Initialize the fee to 0, for local calls
-        uint256 fee = 0;
-        if (isXCall() && xmsg.sourceChainId != omni.chainId()) {
-            // Calculate the fee for the cross-chain call
-            fee = feeFor(xmsg.sourceChainId, abi.encodeWithSelector(this.greet.selector, _greeting), DEST_TX_GAS_LIMIT);
-        }
-
         // Create a Greeting struct to store information about the received greeting
         Greeting memory greeting =
-            Greeting(xmsg.sourceChainId, block.timestamp, fee, msg.sender, xmsg.sender, _greeting);
+            Greeting(xmsg.sourceChainId, block.timestamp, xmsg.sender, _greeting);
 
         // Update the lastGreet variable with the information about the received greeting
         lastGreet = greeting;

--- a/src/Greeting.sol
+++ b/src/Greeting.sol
@@ -5,8 +5,6 @@ pragma solidity ^0.8.23;
 struct Greeting {
     uint64 sourceChainId;   // The source chain ID of the greeting
     uint256 timestamp;      // The timestamp of the greeting
-    uint256 fee;            // The portal fee for the greeting
-    address sender;         // The sender of the greeting
     address xsender;        // The cross-chain sender of the greeting
     string message;         // The message of the greeting
 }

--- a/test/GlobalGreeter.t.sol
+++ b/test/GlobalGreeter.t.sol
@@ -34,8 +34,6 @@ contract GlobalGreeterTest is Test {
         (
             lastGreet.sourceChainId,
             lastGreet.timestamp,
-            lastGreet.fee,
-            lastGreet.sender,
             lastGreet.xsender,
             lastGreet.message
         ) = greeter.lastGreet();
@@ -59,8 +57,6 @@ contract GlobalGreeterTest is Test {
         (
             lastGreet.sourceChainId,
             lastGreet.timestamp,
-            lastGreet.fee,
-            lastGreet.sender,
             lastGreet.xsender,
             lastGreet.message
         ) = greeter.lastGreet();


### PR DESCRIPTION
Couple fixes:
- no need to track "fee" in the Greeting data structure, it's not really part of the Greeting, but the XMsg. Plus it was used incorrectly here
- don't track `sender`, that's always the portal
- remove incorrect logic which calculated the fee on the destination chain, rather than the source

These issues resulted in the Greeter not actually working