### PR TITLE
fix: use xapp isXCall internal view

### DIFF
--- a/src/GreetingBook.sol
+++ b/src/GreetingBook.sol
@@ -21,7 +21,7 @@ contract GreetingBook is XApp {
     constructor(address portal) XApp(portal, ConfLevel.Latest) {}
 
     function greet(address user, string calldata _greeting) external xrecv {
-        require(omni.isXCall(), "GreetingBook: only xcalls");
+        require(isXCall(), "GreetingBook: only xcalls");
 
         lastGreet = Greeting(user, _greeting, xmsg.sourceChainId, block.timestamp);
     }


### PR DESCRIPTION
Use isXCall internal to XApp, rather than portal.isXCall.

This utility confirms the sender is the portal. 